### PR TITLE
v2.7.2

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -5,6 +5,7 @@
 
 - [bug] 修复EntityComponent里的方法回调，需要owner实现该方法后，EntityComponent的回调才会被调用的BUG [Issue #107](https://github.com/KBEngineLab/KBEngine-Nex/issues/107)
 - [bug] mysql9中md5内置方法被移除 [Issue #108](https://github.com/KBEngineLab/KBEngine-Nex/issues/108)
+- [update] mongodbc 升级到2.2.2 [Issue #113](https://github.com/KBEngineLab/KBEngine-Nex/issues/113)
 
 ## 2.7.1
 

--- a/kbe/src/lib/db_mongodb/db_interface_mongodb.cpp
+++ b/kbe/src/lib/db_mongodb/db_interface_mongodb.cpp
@@ -604,15 +604,35 @@ namespace KBEngine {
 	std::unique_ptr<MongoCursorGuard> DBInterfaceMongodb::collectionFind(const char* tableName, mongoc_query_flags_t flags, uint32_t skip, uint32_t limit, uint32_t  batch_size, const bson_t* query, const bson_t* fields, const mongoc_read_prefs_t* read_prefs)
 	{
 		querystatistics("SELECT");
-		mongoc_collection_t* collection = mongoc_database_get_collection(database, tableName);
-		mongoc_cursor_t* cursor = mongoc_collection_find(collection, flags, skip, limit, batch_size, query, fields, read_prefs);
 
-		// 改用MongoCursorGuard+ 智能指针，外部不需要再释放cursor和collection
-		std::unique_ptr<MongoCursorGuard> guard =
-			std::make_unique<MongoCursorGuard>(collection, cursor);
-		// 不 destroy collection
-		// mongoc_collection_destroy(collection);
-		return guard;
+		mongoc_collection_t* collection =
+			mongoc_database_get_collection(database, tableName);
+
+		bson_t opts;
+		bson_init(&opts);
+
+		if (skip > 0)
+			BSON_APPEND_INT64(&opts, "skip", skip);
+
+		if (limit > 0)
+			BSON_APPEND_INT64(&opts, "limit", limit);
+
+		if (batch_size > 0)
+			BSON_APPEND_INT64(&opts, "batchSize", batch_size);
+
+		if (fields)
+			BSON_APPEND_DOCUMENT(&opts, "projection", fields);
+
+		mongoc_cursor_t* cursor =
+			mongoc_collection_find_with_opts(
+				collection,
+				query,
+				&opts,
+				read_prefs);
+
+		bson_destroy(&opts);
+
+		return std::make_unique<MongoCursorGuard>(collection, cursor);
 	}
 
 	bool DBInterfaceMongodb::updateCollection(const char* tableName, mongoc_update_flags_t uflags, const bson_t* selector, const bson_t* update, const mongoc_write_concern_t* write_concern)
@@ -650,33 +670,63 @@ namespace KBEngine {
 	std::unique_ptr<MongoCursorGuard> DBInterfaceMongodb::collectionFindIndexes(const char* tableName)
 	{
 		querystatistics("SELECT_INDEX");
-		bson_error_t error = { 0 };
-		mongoc_collection_t* collection = mongoc_database_get_collection(database, tableName);
-		mongoc_cursor_t* cursor = mongoc_collection_find_indexes(collection, &error);
 
-		// 改用MongoCursorGuard+ 智能指针，外部不需要再释放cursor和collection
-		std::unique_ptr<MongoCursorGuard> guard =
-			std::make_unique<MongoCursorGuard>(collection, cursor);
+		mongoc_collection_t* collection =
+			mongoc_database_get_collection(database, tableName);
 
-		// mongoc_collection_destroy(collection);
-		return guard;
+		bson_t opts;
+		bson_init(&opts);   // 一般可以为空
+
+		mongoc_cursor_t* cursor =
+			mongoc_collection_find_indexes_with_opts(
+				collection,
+				&opts);
+
+		bson_destroy(&opts);
+
+		return std::make_unique<MongoCursorGuard>(collection, cursor);
 	}
 
-	bool DBInterfaceMongodb::collectionCreateIndex(const char* tableName, const bson_t* keys, const mongoc_index_opt_t* opt)
+	bool DBInterfaceMongodb::collectionCreateIndex(const char* tableName, const bson_t* keys, const bson_t* opt)
 	{
 		querystatistics("CREATE_INDEX");
-		mongoc_collection_t* collection = mongoc_database_get_collection(database, tableName);
+
+		mongoc_collection_t* collection =
+			mongoc_database_get_collection(database, tableName);
 
 		bson_error_t error;
-		bool r = mongoc_collection_create_index(collection, keys, opt, &error);
-		if (!r)
+		bool result = false;
+
+		// 创建 index model
+		mongoc_index_model_t* model =
+			mongoc_index_model_new(keys, opt);
+
+		if (!model)
+		{
+			ERROR_MSG("Failed to create index model\n");
+			mongoc_collection_destroy(collection);
+			return false;
+		}
+
+		mongoc_index_model_t* models[] = { model };
+
+		result = mongoc_collection_create_indexes_with_opts(
+			collection,
+			models,
+			1,
+			NULL,   // createIndexes 命令级 opts
+			NULL,   // reply
+			&error);
+
+		if (!result)
 		{
 			ERROR_MSG(fmt::format("{}\n", error.message));
 		}
 
+		mongoc_index_model_destroy(model);
 		mongoc_collection_destroy(collection);
 
-		return r;
+		return result;
 	}
 
 	bool DBInterfaceMongodb::collectionDropIndex(const char* tableName, const char* index_name)
@@ -794,7 +844,7 @@ namespace KBEngine {
 		while (mongoc_cursor_next(guard->cursor(), &doc))
 		{
 			nrows++;
-			char* str = bson_as_json(doc, NULL);
+			char* str = bson_as_relaxed_extended_json(doc, NULL);
 			value.push_back(str);
 		}
 
@@ -1006,7 +1056,7 @@ namespace KBEngine {
 		bool r = extuteFunction(q, NULL, &reply);
 		if (r)
 		{
-			char* str = bson_as_json(&reply, NULL);
+			char* str = bson_as_relaxed_extended_json(&reply, NULL);
 			result->appendBlob(str, static_cast<KBEngine::ArraySize>(strlen(str)));
 			bson_free(str);
 		}

--- a/kbe/src/lib/db_mongodb/db_interface_mongodb.h
+++ b/kbe/src/lib/db_mongodb/db_interface_mongodb.h
@@ -11,8 +11,8 @@
 // #ifdef _MSC_VER //解决mongodb和python中ssize_t冲突定义的问题
 // #define _SSIZE_T_DEFINED
 // #endif
-#include "mongoc.h"
-#include <bson.h>
+#include "mongoc/mongoc.h"
+//#include <bson.h>
 #include <unordered_set>
 
 class MongoCursorGuard;
@@ -155,7 +155,7 @@ namespace KBEngine
 
 		std::unique_ptr<MongoCursorGuard> collectionFindIndexes(const char* tableName);
 
-		bool collectionCreateIndex(const char* tableName, const bson_t* keys, const mongoc_index_opt_t* opt);
+		bool collectionCreateIndex(const char* tableName, const bson_t* keys, const bson_t* opt);
 
 		bool collectionDropIndex(const char* tableName, const char* index_name);
 

--- a/kbe/src/lib/db_mongodb/entity_table_mongodb.cpp
+++ b/kbe/src/lib/db_mongodb/entity_table_mongodb.cpp
@@ -176,7 +176,7 @@ namespace KBEngine {
 		//开始删除多余的索引，增加新的索引
 		bson_t keys;
 		bson_init(&keys);
-		mongoc_index_opt_t opt;
+		bson_t opt;
 
 		std::vector<EntityTableItem*>::iterator iiter = indexs.begin();
 		for (; iiter != indexs.end();)
@@ -203,26 +203,41 @@ namespace KBEngine {
 				}
 			}
 
+			//if (std::string("UNIQUE") == (*iiter)->indexType())
+			//{
+			//	//需要增加唯一索引
+			//	bson_init(&keys);
+			//	mongoc_index_opt_init(&opt);
+			//	opt.unique = true;
+			//	bson_append_int32(&keys, itemIndexsName.c_str(), -1, 1);
+			//	pdbiMongodb->collectionCreateIndex(name, &keys, &opt);
+			//}
+			//else
+			//{
+			//	bson_init(&keys);
+			//	mongoc_index_opt_init(&opt);
+			//	bson_append_int32(&keys, itemIndexsName.c_str(), -1, 1);
+			//	pdbiMongodb->collectionCreateIndex(name, &keys, &opt);
+			//}
+
+
+			bson_init(&keys);
+			bson_init(&opt);
+
+			BSON_APPEND_INT32(&keys, itemIndexsName.c_str(), 1);
+
 			if (std::string("UNIQUE") == (*iiter)->indexType())
 			{
-				//需要增加唯一索引
-				bson_init(&keys);
-				mongoc_index_opt_init(&opt);
-				opt.unique = true;
-				bson_append_int32(&keys, itemIndexsName.c_str(), -1, 1);
-				pdbiMongodb->collectionCreateIndex(name, &keys, &opt);
+				BSON_APPEND_BOOL(&opt, "unique", true);
 			}
-			else
-			{
-				bson_init(&keys);
-				mongoc_index_opt_init(&opt);
-				bson_append_int32(&keys, itemIndexsName.c_str(), -1, 1);
-				pdbiMongodb->collectionCreateIndex(name, &keys, &opt);
-			}
+
+			pdbiMongodb->collectionCreateIndex(name, &keys, &opt);
+
 
 			++iiter;
 		}
 		bson_destroy(&keys);
+		bson_destroy(&opt);
 
 		// 剩下的就是要从数据库删除的index
 		KBEUnordered_map<std::string, std::string>::iterator dbkey_iter = currDBKeys.begin();
@@ -256,16 +271,23 @@ namespace KBEngine {
 			DBInterfaceMongodb* pdbiMongodb = static_cast<DBInterfaceMongodb*>(pdbi);
 			if (pdbiMongodb->createCollection(name))
 			{
-				//第一次创建表，需要对主表ID加索引
-				//需要增加唯一索引
+				// 第一次创建表，需要对主表ID加唯一索引
 				bson_t keys;
-				mongoc_index_opt_t opt;
+				bson_t opts;
+
 				bson_init(&keys);
-				mongoc_index_opt_init(&opt);
-				opt.unique = true;
-				bson_append_int32(&keys, "id", -1, 1);
-				pdbiMongodb->collectionCreateIndex(name, &keys, &opt);
+				bson_init(&opts);
+
+				// key: { id: 1 }
+				BSON_APPEND_INT32(&keys, "id", 1);
+
+				// unique: true
+				BSON_APPEND_BOOL(&opts, "unique", true);
+
+				pdbiMongodb->collectionCreateIndex(name, &keys, &opts);
+
 				bson_destroy(&keys);
+				bson_destroy(&opts);
 			}
 
 			//因为mongodb缺少对数组的批量修改，导致无法像mysql那样做def字段的增加和删改。为了解决这个问题，要发挥mongodb的文件型数据库的的特点

--- a/kbe/src/lib/db_mongodb/entity_table_mongodb.cpp
+++ b/kbe/src/lib/db_mongodb/entity_table_mongodb.cpp
@@ -177,6 +177,7 @@ namespace KBEngine {
 		bson_t keys;
 		bson_init(&keys);
 		bson_t opt;
+		bson_init(&opt);
 
 		std::vector<EntityTableItem*>::iterator iiter = indexs.begin();
 		for (; iiter != indexs.end();)

--- a/kbe/src/server/dbmgr/dbmgr.vcxproj
+++ b/kbe/src/server/dbmgr/dbmgr.vcxproj
@@ -157,7 +157,7 @@
       <AdditionalOptions>/ignore:4049
 /ignore:4217
  %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>Dnsapi.lib;secur32.lib;Rpcrt4.lib;openssl_uptable.obj;crypt32.lib;db_mysql_d.lib;db_mongodb_d.lib;python313_d.lib;Version.lib;wldap32.lib;netapi32.lib;resmgr_d.lib;db_interface_d.lib;server_d.lib;xml_d.lib;common_d.lib;helper_d.lib;math_d.lib;network_d.lib;thread_d.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ncrypt.lib;Dnsapi.lib;secur32.lib;Rpcrt4.lib;openssl_uptable.obj;crypt32.lib;db_mysql_d.lib;db_mongodb_d.lib;python313_d.lib;Version.lib;wldap32.lib;netapi32.lib;resmgr_d.lib;db_interface_d.lib;server_d.lib;xml_d.lib;common_d.lib;helper_d.lib;math_d.lib;network_d.lib;thread_d.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <AdditionalLibraryDirectories>../../libs;../../lib/dependencies/vld;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
@@ -214,7 +214,7 @@
     <Link>
       <AdditionalOptions>/ignore:4049
 /ignore:4217 %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>Dnsapi.lib;secur32.lib;Rpcrt4.lib;openssl_uptable.obj;crypt32.lib;db_mysql.lib;db_mongodb.lib;python313.lib;Version.lib;wldap32.lib;netapi32.lib;resmgr.lib;db_interface.lib;server.lib;xml.lib;common.lib;helper.lib;math.lib;network.lib;thread.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ncrypt.lib;Dnsapi.lib;secur32.lib;Rpcrt4.lib;openssl_uptable.obj;crypt32.lib;db_mysql.lib;db_mongodb.lib;python313.lib;Version.lib;wldap32.lib;netapi32.lib;resmgr.lib;db_interface.lib;server.lib;xml.lib;common.lib;helper.lib;math.lib;network.lib;thread.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <AdditionalLibraryDirectories>../../libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
## 2.7.2

- [bug] 修复EntityComponent里的方法回调，需要owner实现该方法后，EntityComponent的回调才会被调用的BUG [Issue #107](https://github.com/KBEngineLab/KBEngine-Nex/issues/107)
- [bug] mysql9中md5内置方法被移除 [Issue #108](https://github.com/KBEngineLab/KBEngine-Nex/issues/108)
- [update] mongodbc 升级到2.2.2 [Issue #113](https://github.com/KBEngineLab/KBEngine-Nex/issues/113)